### PR TITLE
Use new FSF address in GPL notices

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -2,7 +2,7 @@
 		       Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-                       59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+                       51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/cygwin-elf.h
+++ b/cygwin-elf.h
@@ -14,8 +14,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License along with the GNU C Library; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.  */
+   Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301 USA.  */
 
 #ifndef _ELF_H
 #define	_ELF_H 1


### PR DESCRIPTION
Correct the address of Free Software Foundation via
http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
