### PR TITLE
Fix buffer overflow in output_relocs()

### DIFF
--- a/elf2flt.c
+++ b/elf2flt.c
@@ -336,7 +336,7 @@ output_relocs (
   const char		*sym_name, *section_name;
   unsigned char		*sectionp;
   unsigned long		pflags;
-  char			addstr[16];
+  char			addstr[20];
   uint32_t		sym_addr, sym_vma, section_vma;
   int			relsize, relcount;
   int			flat_reloc_count;


### PR DESCRIPTION
This crash is seen when trying to build uclibc for a ARMV7-M platform on a
x86-64 host:

make[1]: Entering directory `<...>/build/uclibc-1.0.14'
  CC utils/getconf
**\* buffer overflow detected ***: <...>/bin/elf2flt terminated
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x7338f)[0x2ad3be5f738f]
/lib/x86_64-linux-gnu/libc.so.6(__fortify_fail+0x5c)[0x2ad3be68ec9c]
/lib/x86_64-linux-gnu/libc.so.6(+0x109b60)[0x2ad3be68db60]
/lib/x86_64-linux-gnu/libc.so.6(+0x109069)[0x2ad3be68d069]
/lib/x86_64-linux-gnu/libc.so.6(_IO_default_xsputn+0xbc)[0x2ad3be5ff70c]
/lib/x86_64-linux-gnu/libc.so.6(_IO_vfprintf+0xaef)[0x2ad3be5ce7df]
/lib/x86_64-linux-gnu/libc.so.6(__vsprintf_chk+0x84)[0x2ad3be68d0f4]
/lib/x86_64-linux-gnu/libc.so.6(__sprintf_chk+0x7d)[0x2ad3be68d04d]
 <...>/bin/elf2flt[0x403cda]
 <...>/bin/elf2flt[0x4030a4]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf5)[0x2ad3be5a5ec5]
 <...>/bin/elf2flt[0x403642]
...

In output_relocs, we do "sprintf(&addstr[0], "+0x%lx", ...)", with addrstr
being a 16 bytes array.

On 64bits hosts, in the unlikely case the value overflows 32bits, the buffer
may overflow.

Indeed, the maximum theorical size is 20 bytes (16 bytes for the value + 3
bytes for "+0x" + the end of string marker).

The reason the value overflows 32bits is yet to be understood, as the ARMV7-M
is 32bits architecture, but this patch first ensure the sprintf call is robust
enough.

Signed-off-by: Maxime Coquelin mcoquelin.stm32@gmail.com
