### PR TITLE
Fix an uninitialized variable.

### DIFF
--- a/elf2flt.c
+++ b/elf2flt.c
@@ -363,6 +363,7 @@ dump_symbols(symbols, number_of_symbols);
   *n_relocs = 0;
   flat_relocs = NULL;
   flat_reloc_count = 0;
+  sym_reloc_size = 0;
   rc = 0;
   pflags = 0;
   /* Silence gcc warnings */


### PR DESCRIPTION
Uninitialized variable sym_reloc_size triggers -Werror and breaks the compilation.

elf2flt.c: In function 'output_relocs':
elf2flt.c:1604:5: error: 'sym_reloc_size' may be used uninitialized in this function [-Werror=maybe-uninitialized]
printf(" RELOC[%d]: offset=0x%"BFD_VMA_FMT"x symbol=%s%s "

Signed-off-by: Kirill Smirnov kirill.k.smirnov@gmail.com
