### PR TITLE
ld-elf2flt: Resolve symlink for ld

### DIFF
--- a/ld-elf2flt.c
+++ b/ld-elf2flt.c
@@ -473,7 +473,7 @@ static void parse_args(int argc, char **argv)
 
 int main(int argc, char *argv[])
 {
-	const char *argv0 = argv[0];
+	const char *argv0 = lrealpath(argv[0]);
 	const char *argv0_dir = make_relative_prefix(argv0, "/", "/");
 	const char *tooldir = argv0_dir;
 	const char *bindir = argv0_dir;


### PR DESCRIPTION
<prefix>-ld can be symlinked to just ld and treated by gcc as
an ordinary target linker. To support this use-case, ld-elf2flt
should be resolved to its original name (and path too). Otherwise
ld.real won't be found.

Scenario like this can be found in crosstool-ng package. This patch
fixes pass-2 compiler.

Signed-off-by: Kirill K. Smirnov kirill.k.smirnov@gmail.com
