### PR TITLE
Fix build on Cygwin

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -38,11 +38,6 @@ ifneq (,$(findstring mingw32,$(HOST)))
    LDLIBS += -lws2_32
 endif
 
-# force link order under cygwin to avoid getopts / libiberty clash
-ifneq ($(strip $(shell gcc -v 2>&1 | grep "cygwin")),)
-   LDLIBS := -lcygwin $(LDLIBS)
-endif
-
 LDFILE= elf2flt.ld
 ifeq ($(strip $(CPU)),e1)
 SRC_LDFILE= $(srcdir)/$(CPU)-elf2flt.ld

--- a/configure
+++ b/configure
@@ -3983,46 +3983,6 @@ case $target in
 		;;
 esac
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for malloc in -lc" >&5
-$as_echo_n "checking for malloc in -lc... " >&6; }
-if ${ac_cv_lib_c_malloc+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lc  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char malloc ();
-int
-main ()
-{
-return malloc ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_c_malloc=yes
-else
-  ac_cv_lib_c_malloc=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_c_malloc" >&5
-$as_echo "$ac_cv_lib_c_malloc" >&6; }
-if test "x$ac_cv_lib_c_malloc" = xyes; then :
-  LIBS="-lc $LIBS"
-fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
 $as_echo_n "checking for dlopen in -ldl... " >&6; }
 if ${ac_cv_lib_dl_dlopen+:} false; then :

--- a/configure.ac
+++ b/configure.ac
@@ -187,12 +187,6 @@ case $target in
 		;;
 esac
 
-dnl Make sure we resolve system symbols before libiberty/libbfd ones.
-dnl Otherwise, things like getopt get screwed up because the system headers
-dnl redirect some functions to the system symbols, but other local symbols
-dnl come from libiberty/libbfd.
-dnl int getopt(int, char * const [], const char *) __asm("_" "getopt" "$UNIX2003");
-AC_CHECK_LIB(c, malloc, LIBS="-lc $LIBS")
 AC_CHECK_LIB(dl, dlopen, LIBS="$LIBS -ldl")
 
 dnl Checks for header files.


### PR DESCRIPTION
The -lcygwin -lc actually breaks the build: elf2flt picks up the symbols
for getopt/optarg via <getopt.h> in binutils-X.Y/include, where optarg
is declared without dllimport attribute.  Therefore it pulls in getopt()
from libc/libcygwin, but since optarg is not prefixed with _imp__, it is
pulled from libiberty. But the object file in libiberty also contains
getopt() thus resulting in multiple definitions thereof.

Signed-off-by: Alexey Neyman <stilor@att.net>