### PR TITLE
Create symlink to <bfd/diagnostics.h> in bfd-headers

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -123,11 +123,16 @@ sinclude .deps
 	$(CC) -MM $(CPPFLAGS) $(srcdir)/*.c > .deps
 
 
+# Some versions of binutils may not have all these headers (diagnostics.h
+# appeared in binutils 2.31; bfd_stdint.h in 2.32) so some symlinks may be
+# dangling.
 bfd-headers/.stamp:
 	rm -rf bfd-headers
 	mkdir bfd-headers
-	ln -sf $(BFD_INCLUDE_DIR)/bfd.h bfd-headers/bfd.h
-	for f in ansidecl filenames hashtab libiberty symcat; do \
+	for f in bfd bfd_stdint; do \
+		ln -sf $(BFD_INCLUDE_DIR)/$$f.h bfd-headers/$$f.h || exit 1; \
+	done
+	for f in ansidecl diagnostics filenames hashtab libiberty symcat; do \
 		ln -sf $(BINUTILS_INCLUDE_DIR)/$$f.h bfd-headers/$$f.h || exit 1; \
 	done
 	ln -sf $(BINUTILS_INCLUDE_DIR)/elf bfd-headers/elf


### PR DESCRIPTION
Included by <bfd/bfd.h>.

Signed-off-by: Alexey Neyman <stilor@att.net>