### PR TITLE
Check `output_elf' for being NULL

### DIFF
--- a/ld-elf2flt.c
+++ b/ld-elf2flt.c
@@ -568,7 +568,9 @@ int main(int argc, char *argv[])
 	if (!flag_verbose) {
 		unlink(tmp_file);
 		unlink(output_flt);
-		unlink(output_elf);
+		if (output_elf) {
+			unlink(output_elf);
+		}
 	} else {
 		fprintf(stderr,
 			"leaving elf2flt temp files behind:\n"


### PR DESCRIPTION
... before passing it to unlink(). GCC8.2 detects that one of the
branches in do_final_link() does not initialize it from its original
value, NULL.

Signed-off-by: Alexey Neyman <stilor@att.net>