### PR TITLE
elf2flt.c: add new relocation types for xtensa

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -30,7 +30,8 @@ DEFS = @DEFS@ \
 	-DNO_GOT_CHECK=@got_check@ \
 	-DUSE_EMIT_RELOCS=@emit_relocs@ \
 	-DEMIT_CTOR_DTOR=@emit_ctor_dtor@ \
-	-DALWAYS_RELOC_TEXT=@always_reloc_text@
+	-DALWAYS_RELOC_TEXT=@always_reloc_text@ \
+	-DHAVE_BFD_XTENSA_PDIFF_RELOCS=@HAVE_BFD_XTENSA_PDIFF_RELOCS@
 EXEEXT = @EXEEXT@
 OBJEXT = @OBJEXT@
 

--- a/configure
+++ b/configure
@@ -621,6 +621,7 @@ ac_includes_default="\
 
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
+HAVE_BFD_XTENSA_PDIFF_RELOCS
 SYMBOL_PREFIX
 always_reloc_text
 emit_ctor_dtor
@@ -1728,6 +1729,52 @@ fi
   as_fn_set_status $ac_retval
 
 } # ac_fn_c_try_link
+
+# ac_fn_c_check_decl LINENO SYMBOL VAR INCLUDES
+# ---------------------------------------------
+# Tests whether SYMBOL is declared in INCLUDES, setting cache variable VAR
+# accordingly.
+ac_fn_c_check_decl ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  as_decl_name=`echo $2|sed 's/ *(.*//'`
+  as_decl_use=`echo $2|sed -e 's/(/((/' -e 's/)/) 0&/' -e 's/,/) 0& (/g'`
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $as_decl_name is declared" >&5
+$as_echo_n "checking whether $as_decl_name is declared... " >&6; }
+if eval \${$3+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$4
+int
+main ()
+{
+#ifndef $as_decl_name
+#ifdef __cplusplus
+  (void) $as_decl_use;
+#else
+  (void) $as_decl_name;
+#endif
+#endif
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  eval "$3=yes"
+else
+  eval "$3=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+eval ac_res=\$$3
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+
+} # ac_fn_c_check_decl
 
 # ac_fn_c_check_func LINENO FUNC VAR
 # ----------------------------------
@@ -4272,6 +4319,22 @@ $as_echo "#define const /**/" >>confdefs.h
 fi
 
 
+HAVE_BFD_XTENSA_PDIFF_RELOCS=0
+case $target in
+	xtensa*)
+		OLD_CPPFLAGS=$CPPFLAGS
+		CPPFLAGS="-I$bfd_include_dir -I$binutils_include_dir $CPPFLAGS"
+		ac_fn_c_check_decl "$LINENO" "R_XTENSA_PDIFF8" "ac_cv_have_decl_R_XTENSA_PDIFF8" "#include \"bfd.h\"
+			       #include \"elf/xtensa.h\"
+"
+if test "x$ac_cv_have_decl_R_XTENSA_PDIFF8" = xyes; then :
+  HAVE_BFD_XTENSA_PDIFF_RELOCS=1
+fi
+
+		CPPFLAGS=$OLD_CPPFLAGS
+		;;
+esac
+
 for ac_func in vprintf
 do :
   ac_fn_c_check_func "$LINENO" "vprintf" "ac_cv_func_vprintf"
@@ -4316,6 +4379,7 @@ if test "$GCC" = yes ; then
 		CFLAGS="-Werror -Wno-error=unused-label $CFLAGS"
 	fi
 fi
+
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -202,6 +202,19 @@ AC_CHECK_HEADERS(fcntl.h unistd.h bfd.h)
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
 
+HAVE_BFD_XTENSA_PDIFF_RELOCS=0
+case $target in
+	xtensa*)
+		AS_VAR_COPY([OLD_CPPFLAGS], [CPPFLAGS])
+		AS_VAR_SET([CPPFLAGS], ["-I$bfd_include_dir -I$binutils_include_dir $CPPFLAGS"])
+		AC_CHECK_DECL([R_XTENSA_PDIFF8],
+			      [HAVE_BFD_XTENSA_PDIFF_RELOCS=1],,
+			      [#include "bfd.h"
+			       #include "elf/xtensa.h"])
+		AS_VAR_COPY([CPPFLAGS], [OLD_CPPFLAGS])
+		;;
+esac
+
 dnl Checks for library functions.
 AC_FUNC_VPRINTF
 
@@ -235,6 +248,7 @@ AC_SUBST(emit_relocs)
 AC_SUBST(emit_ctor_dtor)
 AC_SUBST(always_reloc_text)
 AC_SUBST(SYMBOL_PREFIX)
+AC_SUBST(HAVE_BFD_XTENSA_PDIFF_RELOCS)
 
 AC_OUTPUT(ld-elf2flt.sh:ld-elf2flt.in Makefile elf2flt.ld)
 

--- a/elf2flt.c
+++ b/elf2flt.c
@@ -776,6 +776,14 @@ output_relocs (
 				case R_XTENSA_DIFF8:
 				case R_XTENSA_DIFF16:
 				case R_XTENSA_DIFF32:
+#if HAVE_BFD_XTENSA_PDIFF_RELOCS
+				case R_XTENSA_PDIFF8:
+				case R_XTENSA_PDIFF16:
+				case R_XTENSA_PDIFF32:
+				case R_XTENSA_NDIFF8:
+				case R_XTENSA_NDIFF16:
+				case R_XTENSA_NDIFF32:
+#endif
 				case R_XTENSA_32_PCREL:
 					continue;
 				case R_XTENSA_32:


### PR DESCRIPTION
Xtensa have added new relocation types R_XTENSA_[NP]DIFF{8,16,32} with
the same properties as the existing types R_XTENSA_DIFF{8,16,32}.
Add them to the list of ignored relocation types.

This fixes the following error when invoking elf2flt on xtensa binaries
built with the recent binutils:

  ERROR: reloc type R_XTENSA_PDIFF32 unsupported in this context

Reported-by: Romain Naour <romain.naour@gmail.com>
Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>