### PR TITLE
elf2flt: add riscv support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -44,7 +44,9 @@ endif
 LDFILE= elf2flt.ld
 ifeq ($(strip $(CPU)),e1)
 SRC_LDFILE= $(srcdir)/$(CPU)-elf2flt.ld
-else 
+else ifeq ($(strip $(CPU)),riscv64)
+SRC_LDFILE= $(srcdir)/$(CPU)-elf2flt.ld
+else
 SRC_LDFILE= elf2flt.ld
 endif
 

--- a/elf2flt.c
+++ b/elf2flt.c
@@ -81,6 +81,8 @@ const char *elf2flt_progname;
 #include <elf/v850.h>
 #elif defined(TARGET_xtensa)
 #include <elf/xtensa.h>
+#elif defined(TARGET_riscv64)
+#include <elf/riscv.h>
 #endif
 
 #if defined(__MINGW32__)
@@ -123,6 +125,8 @@ const char *elf2flt_progname;
 #define ARCH	"nios2"
 #elif defined(TARGET_xtensa)
 #define ARCH	"xtensa"
+#elif defined(TARGET_riscv64)
+#define ARCH	"riscv64"
 #else
 #error "Don't know how to support your CPU architecture??"
 #endif
@@ -808,6 +812,15 @@ output_relocs (
 					continue;
 				case R_XTENSA_32:
 				case R_XTENSA_PLT:
+					goto good_32bit_resolved_reloc;
+				default:
+					goto bad_resolved_reloc;
+#elif defined(TARGET_riscv64)
+				case R_RISCV_32_PCREL:
+				case R_RISCV_ADD32:
+				case R_RISCV_SUB32:
+					break;
+				case R_RISCV_64:
 					goto good_32bit_resolved_reloc;
 				default:
 					goto bad_resolved_reloc;
@@ -1830,6 +1843,15 @@ int main(int argc, char *argv[])
    */
   if (!load_to_ram && !pfile)
     load_to_ram = 1;
+
+#if defined(TARGET_riscv64)
+  /*
+   * riscv only supports loading text and data contiguously.
+   * So fail if load_to_ram is false.
+   */
+  if (!load_to_ram)
+    fatal("Loading to RAM ('-r' option) is required");
+#endif
 
   fname = argv[argc-1];
 

--- a/riscv64-elf2flt.ld
+++ b/riscv64-elf2flt.ld
@@ -1,0 +1,197 @@
+ENTRY (_start)
+
+MEMORY {
+	flatmem : ORIGIN = 0x0, LENGTH = 0xfffffff
+}
+
+PHDRS {
+	text PT_LOAD ;
+	data PT_LOAD ;
+}
+
+SECTIONS {
+
+	.text 0x0 : {
+		. = . + 4;
+		. = ALIGN(0x4) ;
+		_stext = . ;
+		*(.literal .text)
+		*(.literal.* .text.*)
+		*(.gnu.warning)
+		*(.stub)
+		*(.gnu.linkonce.literal.*)
+		*(.gnu.linkonce.t*)
+		*(.glue_7t)
+		*(.glue_7)
+		*(.jcr)
+		*(.init.literal)
+		KEEP (*(.init))
+		*(.fini.literal)
+		KEEP (*(.fini))
+
+W_RODAT		*(.rodata)
+W_RODAT		*(.rodata1)
+W_RODAT		*(.rodata.*)
+W_RODAT		*(.gnu.linkonce.r*)
+
+		/* This is special code area at the end of the normal
+		   text section.  It contains a small lookup table at
+		   the start followed by the code pointed to by entries
+		   in the lookup table.  */
+		. = ALIGN (4) ;
+		PROVIDE(__ctbp = .);
+		*(.call_table_data)
+		*(.call_table_text)
+
+		. = ALIGN(0x10) ;
+		_etext = . ;
+	} > flatmem :text
+
+	.data : {
+		. = ALIGN(0x20) ;
+		_sdata = . ;
+		__data_start = . ;
+		data_start = . ;
+		*(.got)
+		*(.got.plt)
+		*(.igot)
+		*(.igot.plt)
+		FILL(0) ;
+		. = ALIGN(0x20) ;
+		LONG(-1)
+		. = ALIGN(0x20) ;
+
+		__global_pointer$ = . + 0x800;
+
+R_RODAT		*(.rodata)
+R_RODAT		*(.rodata1)
+R_RODAT		*(.rodata.*)
+R_RODAT		*(.gnu.linkonce.r*)
+		*(.data)
+		*(.data1)
+		*(.data.*)
+		*(.gnu.linkonce.d*)
+
+		*(.gnu.linkonce.s.*)
+		*(__libc_atexit)
+		*(__libc_subinit)
+		*(__libc_subfreeres)
+
+		. = ALIGN(4) ;
+TOR:		__CTOR_LIST__ = .;
+TOR:		LONG((__CTOR_END__ - __CTOR_LIST__) / 4 - 2)
+SINGLE_LINK:	/* gcc uses crtbegin.o to find the start of
+SINGLE_LINK:	   the constructors, so we make sure it is
+SINGLE_LINK:	   first.  Because this is a wildcard, it
+SINGLE_LINK:	   doesn't matter if the user does not
+SINGLE_LINK:	   actually link against crtbegin.o; the
+SINGLE_LINK:	   linker won't look for a file to match a
+SINGLE_LINK:	   wildcard.  The wildcard also means that it
+SINGLE_LINK:	   doesn't matter which directory crtbegin.o
+SINGLE_LINK:	   is in.  */
+SINGLE_LINK:	KEEP (*crtbegin*.o(.ctors))
+SINGLE_LINK:	/* We don't want to include the .ctor section from
+SINGLE_LINK:	   from the crtend.o file until after the sorted ctors.
+SINGLE_LINK:	   The .ctor section from the crtend file contains the
+SINGLE_LINK:	   end of ctors marker and it must be last */
+SINGLE_LINK:	KEEP (*(EXCLUDE_FILE (*crtend*.o ) .ctors))
+SINGLE_LINK:	KEEP (*(SORT(.ctors.*)))
+		KEEP (*(.ctors))
+TOR:		LONG(0)
+TOR:		__CTOR_END__ = .;
+TOR:		__DTOR_LIST__ = .;
+TOR:		LONG((__DTOR_END__ - __DTOR_LIST__) / 4 - 2)
+SINGLE_LINK:	KEEP (*crtbegin*.o(.dtors))
+SINGLE_LINK:	KEEP (*(EXCLUDE_FILE (*crtend*.o ) .dtors))
+SINGLE_LINK:	KEEP (*(SORT(.dtors.*)))
+		KEEP (*(.dtors))
+TOR:		LONG(0)
+TOR:		__DTOR_END__ = .;
+
+		PROVIDE (__preinit_array_start = .);
+		KEEP (*(.preinit_array))
+		PROVIDE (__preinit_array_end = .);
+
+		PROVIDE (__init_array_start = .);
+		KEEP (*(SORT(.init_array.*)))
+		KEEP (*(.init_array))
+		PROVIDE (__init_array_end = .);
+
+		PROVIDE (__fini_array_start = .);
+		KEEP (*(.fini_array))
+		KEEP (*(SORT(.fini_array.*)))
+		PROVIDE (__fini_array_end = .);
+
+		. = ALIGN(0x10) ;
+		_edata = . ;
+	} > flatmem :data
+
+	.note.ABI-tag : { *(.note.ABI-tag) } > flatmem
+	.eh_frame_hdr : { *(.eh_frame_hdr) } > flatmem
+	.eh_frame : { KEEP(*(.eh_frame)) } > flatmem
+	.gcc_except_table : {
+		KEEP(*(.gcc_except_table))
+		KEEP(*(.gcc_except_table.*))
+	} > flatmem
+
+	.bss : {
+		. = ALIGN(0x4) ;
+		_sbss = ALIGN(0x4) ;
+		__bss_start = . ;
+		*(.dynsbss)
+		*(.sbss)
+		*(.sbss.*)
+		*(.scommon)
+		*(.dynbss)
+		*(.bss)
+		*(.bss.*)
+		*(.bss*)
+		*(.gnu.linkonce.b*)
+		*(COMMON)
+		. = ALIGN(0x10) ;
+		_ebss = . ;
+		_end = . ;
+		end = . ;
+	} > flatmem
+
+	.stack : {
+		. = ALIGN(0x4);
+		_stack_start = .;
+	} > flatmem
+
+	.junk 0 : { *(.rel*) *(.rela*) }
+	/DISCARD/ : { *(.note.GNU-stack) }
+	/* Stabs debugging sections.    */
+	.stab 0 : { *(.stab) }
+	.stabstr 0 : { *(.stabstr) }
+	.stab.excl 0 : { *(.stab.excl) }
+	.stab.exclstr 0 : { *(.stab.exclstr) }
+	.stab.index 0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment 0 : { *(.comment) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1 */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2 */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2 */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+}


### PR DESCRIPTION
We need a new linker script - riscv has a global_pointer and is
very picky about some section ordering.

Signed-off-by: Christoph Hellwig <hch@lst.de>
Signed-off-by: Damien Le Moal <damien.lemoal@wdc.com>