### PR TITLE
elf2flt: add riscv 64-bits support

### DIFF
--- a/elf2flt.c
+++ b/elf2flt.c
@@ -1877,8 +1877,9 @@ int main(int argc, char *argv[])
     bfd_vma sec_vma;
 
     if ((s->flags & SEC_CODE) ||
-       ((s->flags & (SEC_DATA | SEC_READONLY | SEC_RELOC)) ==
-                    (SEC_DATA | SEC_READONLY | SEC_RELOC))) {
+        (((s->flags & (SEC_DATA | SEC_READONLY | SEC_RELOC)) ==
+                     (SEC_DATA | SEC_READONLY | SEC_RELOC)) &&
+          !data_len)) {
       vma = &text_vma;
       len = &text_len;
     } else if (s->flags & SEC_DATA) {

--- a/elf2flt.c
+++ b/elf2flt.c
@@ -81,6 +81,8 @@ const char *elf2flt_progname;
 #include <elf/v850.h>
 #elif defined(TARGET_xtensa)
 #include <elf/xtensa.h>
+#elif defined(TARGET_riscv64)
+#include <elf/riscv.h>
 #endif
 
 #if defined(__MINGW32__)
@@ -123,6 +125,8 @@ const char *elf2flt_progname;
 #define ARCH	"nios2"
 #elif defined(TARGET_xtensa)
 #define ARCH	"xtensa"
+#elif defined(TARGET_riscv64)
+#define ARCH	"riscv64"
 #else
 #error "Don't know how to support your CPU architecture??"
 #endif
@@ -809,6 +813,18 @@ output_relocs (
 					continue;
 				case R_XTENSA_32:
 				case R_XTENSA_PLT:
+					goto good_32bit_resolved_reloc;
+				default:
+					goto bad_resolved_reloc;
+#elif defined(TARGET_riscv64)
+				case R_RISCV_32_PCREL:
+				case R_RISCV_ADD32:
+				case R_RISCV_ADD64:
+				case R_RISCV_SUB32:
+				case R_RISCV_SUB64:
+					continue;
+				case R_RISCV_32:
+				case R_RISCV_64:
 					goto good_32bit_resolved_reloc;
 				default:
 					goto bad_resolved_reloc;

--- a/elf2flt.ld.in
+++ b/elf2flt.ld.in
@@ -94,12 +94,9 @@ W_RODAT:	*(.gnu.linkonce.r*)
 		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
 	} > flatmem
 	@SYMBOL_PREFIX@__exidx_end = .;
-
-	. = ALIGN(0x20) ;
 	@SYMBOL_PREFIX@_etext = . ;
 
-	.data : {
-		. = ALIGN(0x4) ;
+	.data ALIGN(0x20): {
 		@SYMBOL_PREFIX@_sdata = . ;
 		@SYMBOL_PREFIX@__data_start = . ;
 		@SYMBOL_PREFIX@data_start = . ;

--- a/elf2flt.ld.in
+++ b/elf2flt.ld.in
@@ -106,6 +106,7 @@ W_RODAT:	*(.gnu.linkonce.r*)
 		. = ALIGN(0x20) ;
 		LONG(-1)
 		. = ALIGN(0x20) ;
+RISCV_GP:	__global_pointer$ = . + 0x800 ;
 R_RODAT:	*(.rodata)
 R_RODAT:	*(.rodata1)
 R_RODAT:	*(.rodata.*)

--- a/ld-elf2flt.c
+++ b/ld-elf2flt.c
@@ -324,6 +324,14 @@ static int do_final_link(void)
 		append_option(&other_options, concat(got_offset, "=", buf, NULL));
 	}
 
+	/* riscv adds a global pointer symbol to the linker file with the
+	   "RISCV_GP:" prefix. Remove the prefix for riscv64 architecture and
+	   the entire line for other architectures. */
+	if (streq(TARGET_CPU, "riscv64"))
+		append_sed(&sed, "^RISCV_GP:", "");
+	else
+		append_sed(&sed, "^RISCV_GP:", NULL);
+
 	/* Locate the default linker script, if we don't have one provided. */
 	if (!linker_script)
 		linker_script = concat(ldscriptpath, "/elf2flt.ld", NULL);


### PR DESCRIPTION
Add support for riscv 64bits ISA by defining the relocation types
R_RISCV_32_PCREL, R_RISCV_ADD32, R_RISCV_SUB32, R_RISCV_32 and
R_RISCV_64. riscv64 support also needs the __global_pointer$ symbol to
be defined right after the relocation tables in the data section.
Furthermore, the .got and .got.plt sections must be reversed. These 2
requirements are handled with runtime modifications of the default
linker script using the append_sed() function.
(1) For the .got.plt and .got sections order swap, append_sed() is used
to rename "(.got.plt)" to "(.got.tmp)" and to rename "(.got)" to
"(.got.plt)". A last call finalize the name swap by replacing
"(.got.tmp)" with "(.got)"
(2) For the global pointer synbol, a definition line starting with
"RV64_GP" is added. The "RV64_GP" string is removed if the target CPU
type is riscv64. The definition line is dropped for other CPU types.

With these changes, buildroot/busybox builds and run on NOMMU
systems with kernel 5.13. Tested on Canaan Kendryte K210 boards.

This patch is based on earlier work by Christoph Hellwig <hch@lst.de>.

Signed-off-by: Damien Le Moal <damien.lemoal@wdc.com>