### PR TITLE
elf2flt.ld: align .data section to 32 byte boundary once again

### DIFF
--- a/elf2flt.ld.in
+++ b/elf2flt.ld.in
@@ -94,12 +94,9 @@ W_RODAT:	*(.gnu.linkonce.r*)
 		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
 	} > flatmem
 	@SYMBOL_PREFIX@__exidx_end = .;
-
-	. = ALIGN(0x20) ;
 	@SYMBOL_PREFIX@_etext = . ;
 
-	.data : {
-		. = ALIGN(0x4) ;
+	.data ALIGN(0x20): {
 		@SYMBOL_PREFIX@_sdata = . ;
 		@SYMBOL_PREFIX@__data_start = . ;
 		@SYMBOL_PREFIX@data_start = . ;


### PR DESCRIPTION
Commit 8a3e74446fe7 ("allow to build arm flat binaries") changed the
elf2flt.ld.in linker script by moving the _etext symbol and the matching
alignment directive out of the .text section.

Before commit 8a3e74446fe7 ("allow to build arm flat binaries"):
$ readelf -S output/build/busybox-1.35.0/busybox_unstripped.gdb | grep data
  [ 3] .data             PROGBITS         0000000000035ac0  00036ac0
$ readelf -s output/build/busybox-1.35.0/busybox_unstripped.gdb | grep _etext
 19286: 0000000000035ac0     0 NOTYPE  GLOBAL DEFAULT    1 _etext

After the commit ("allow to build arm flat binaries"):
$ readelf -S output/build/busybox-1.35.0/busybox_unstripped.gdb | grep data
  [ 3] .data             PROGBITS         0000000000035ab0  00036ab0
$ readelf -s output/build/busybox-1.35.0/busybox_unstripped.gdb | grep _etext
 19287: 0000000000035ac0     0 NOTYPE  GLOBAL DEFAULT    3 _etext

Moving the _etext symbol out of the .text section had the side effect that
the .data section was no longer aligned to a 32 byte boundary.

Commit ea6b2f28b085 ("arm expects the data segment on a 32 byte boundary,
otherwise the GOT entries can throw the alignment of the relocations out
and things get pretty ugly from there.") added this for a good reason.

Commit 8a3e74446fe7 ("allow to build arm flat binaries") removed this
alignment, most likely unintentionally. Readd an explicit ALIGN directive
on the .data section, so that the .data section once again is aligned to
a 32 byte boundary. This way should be more robust compared to aligning
the end of the previous section.

This also matches the FLAT_DATA_ALIGN 0x20 macro in fs/binfmt_flat.c:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/binfmt_flat.c?h=v5.17#n59

Signed-off-by: Niklas Cassel <niklas.cassel@wdc.com>