### PR TITLE
xtensa: fix text relocations

### DIFF
--- a/elf2flt.c
+++ b/elf2flt.c
@@ -808,7 +808,20 @@ output_relocs (
 					continue;
 				case R_XTENSA_32:
 				case R_XTENSA_PLT:
-					goto good_32bit_resolved_reloc;
+					if (bfd_big_endian (abs_bfd))
+						sym_addr =
+							(r_mem[0] << 24)
+							+ (r_mem[1] << 16)
+							+ (r_mem[2] << 8)
+							+ r_mem[3];
+					else
+						sym_addr =
+							r_mem[0]
+							+ (r_mem[1] << 8)
+							+ (r_mem[2] << 16)
+							+ (r_mem[3] << 24);
+					relocation_needed = 1;
+					break;
 				default:
 					goto bad_resolved_reloc;
 #else


### PR DESCRIPTION
The commit 5e08f1968316 ("Don't always update text in !pic_with_got case") changed good_32bit_resolved_reloc to not do endianness swapping for relocated entries in the text segment. This broke little-endian xtensa FLAT images which after this change fail to start with the following message:

  binfmt_flat: reloc outside program 0x24c80100 (0 - 0x6e430/0x56a20)

Fix it by preserving 'update_text' when building for xtensa.

Fixes: 5e08f1968316 ("Don't always update text in !pic_with_got case")
Reported-by: Niklas Cassel <niklas.cassel@wdc.com>
Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>