### PR TITLE
Gregungerer/arm exidx fix

### DIFF
--- a/elf2flt.c
+++ b/elf2flt.c
@@ -431,9 +431,7 @@ output_relocs (
 	 * Only relocate things in the writable data sections if we are PIC/GOT.
 	 * Otherwise do text (and read only data) as well.
 	 */
-	if ((!pic_with_got || ALWAYS_RELOC_TEXT) &&
-	    ((a->flags & SEC_CODE) ||
-	    ((a->flags & (SEC_DATA | SEC_READONLY)) == (SEC_DATA | SEC_READONLY))))
+	if ((!pic_with_got || ALWAYS_RELOC_TEXT) && (a->flags & SEC_CODE))
 		sectionp = text + (a->vma - text_vma);
 	else if (a->flags & SEC_DATA)
 		sectionp = data + (a->vma - data_vma);

--- a/elf2flt.c
+++ b/elf2flt.c
@@ -433,8 +433,7 @@ output_relocs (
 	 */
 	if ((!pic_with_got || ALWAYS_RELOC_TEXT) &&
 	    ((a->flags & SEC_CODE) ||
-	    ((a->flags & (SEC_DATA | SEC_READONLY | SEC_RELOC)) ==
-		         (SEC_DATA | SEC_READONLY | SEC_RELOC))))
+	    ((a->flags & (SEC_DATA | SEC_READONLY)) == (SEC_DATA | SEC_READONLY))))
 		sectionp = text + (a->vma - text_vma);
 	else if (a->flags & SEC_DATA)
 		sectionp = data + (a->vma - data_vma);
@@ -1885,9 +1884,7 @@ int main(int argc, char *argv[])
     bfd_size_type sec_size;
     bfd_vma sec_vma;
 
-    if ((s->flags & SEC_CODE) ||
-       ((s->flags & (SEC_DATA | SEC_READONLY | SEC_RELOC)) ==
-                    (SEC_DATA | SEC_READONLY | SEC_RELOC))) {
+    if (s->flags & SEC_CODE) {
       vma = &text_vma;
       len = &text_len;
     } else if (s->flags & SEC_DATA) {
@@ -1920,13 +1917,9 @@ int main(int argc, char *argv[])
   if (verbose)
     printf("TEXT -> vma=0x%x len=0x%x\n", text_vma, text_len);
 
-  /* Read input sections destined for the text output segment.
-   * Includes code sections, but also includes read-only relocation
-   * data sections.*/
+  /* Read in all text sections.  */
   for (s = abs_bfd->sections; s != NULL; s = s->next)
-    if ((s->flags & SEC_CODE) ||
-       ((s->flags & (SEC_DATA | SEC_READONLY | SEC_RELOC)) ==
-                    (SEC_DATA | SEC_READONLY | SEC_RELOC)))
+    if (s->flags & SEC_CODE)
       if (!bfd_get_section_contents(abs_bfd, s,
 				   text + (s->vma - text_vma), 0,
 				   elf2flt_bfd_section_size(s)))
@@ -1950,13 +1943,9 @@ int main(int argc, char *argv[])
     text_len = data_vma - text_vma;
   }
 
-  /* Read input sections destined for the data output segment.
-   * Includes data sections, but not those read-only relocation
-   * data sections already included in the text output section.*/
+  /* Read in all data sections.  */
   for (s = abs_bfd->sections; s != NULL; s = s->next)
-    if ((s->flags & SEC_DATA) &&
-       ((s->flags & (SEC_READONLY | SEC_RELOC)) !=
-                    (SEC_READONLY | SEC_RELOC)))
+    if (s->flags & SEC_DATA)
       if (!bfd_get_section_contents(abs_bfd, s,
 				   data + (s->vma - data_vma), 0,
 				   elf2flt_bfd_section_size(s)))

--- a/elf2flt.ld.in
+++ b/elf2flt.ld.in
@@ -76,6 +76,12 @@ W_RODAT:	*(.gnu.linkonce.r*)
 
 		/* .ARM.extab name sections containing exception unwinding information */
 		*(.ARM.extab* .gnu.linkonce.armextab.*)
+
+		/* .ARM.exidx name sections containing index entries for section unwinding */
+		@SYMBOL_PREFIX@__exidx_start = .;
+		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
+		@SYMBOL_PREFIX@__exidx_end = .;
+
 		/* This is special code area at the end of the normal
 		   text section.  It contains a small lookup table at
 		   the start followed by the code pointed to by entries
@@ -84,19 +90,10 @@ W_RODAT:	*(.gnu.linkonce.r*)
 		PROVIDE(@SYMBOL_PREFIX@__ctbp = .);
 		*(.call_table_data)
 		*(.call_table_text)
+
+		. = ALIGN(0x20) ;
+		@SYMBOL_PREFIX@_etext = . ;
 	} > flatmem :text
-
-	/* .ARM.exidx name sections containing index entries for section unwinding */
-	/* .ARM.exidx is sorted, so has to go in its own output section.  */
-	@SYMBOL_PREFIX@__exidx_start = .;
-	.ARM.exidx :
-	{
-		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
-	} > flatmem
-	@SYMBOL_PREFIX@__exidx_end = .;
-
-	. = ALIGN(0x20) ;
-	@SYMBOL_PREFIX@_etext = . ;
 
 	.data : {
 		. = ALIGN(0x4) ;


### PR DESCRIPTION
This is a different approach to fixing the issues that elf2flt has had with dumping and invalid relocations that stem from the ARM.exidx section problem. This reverts the fix and follow up fix that still has breakage on some architectures.

The change here now is to explicitly include the ARM.exidx section in the elf2flt text section in the linker script - instead of keeping it as a separate named section. With that section now inside the text section proper there is no sizing or alignment problems for and between the text and data sections.

This approach should also means that no further special cases are required fix eh_frames and similar issues.