### PR TITLE
elf2flt: xtensa: fix text relocations

### DIFF
--- a/elf2flt.c
+++ b/elf2flt.c
@@ -815,7 +815,7 @@ output_relocs (
 					continue;
 				case R_XTENSA_32:
 				case R_XTENSA_PLT:
-					goto good_32bit_resolved_reloc;
+					goto good_32bit_resolved_reloc_update_text;
 				default:
 					goto bad_resolved_reloc;
 #else
@@ -830,6 +830,8 @@ output_relocs (
 					goto good_32bit_resolved_reloc;
 #endif
 				good_32bit_resolved_reloc:
+					update_text = 0;
+				good_32bit_resolved_reloc_update_text:
 					if (bfd_big_endian (abs_bfd))
 						sym_addr =
 							(r_mem[0] << 24)
@@ -843,7 +845,6 @@ output_relocs (
 							+ (r_mem[2] << 16)
 							+ (r_mem[3] << 24);
 					relocation_needed = 1;
-					update_text = 0;
 					break;
 
 				bad_resolved_reloc:


### PR DESCRIPTION
The commit 5e08f1968316 ("Don't always update text in !pic_with_got case") changed good_32bit_resolved_reloc to not do endianness swapping for relocated entries in the text segment. This broke little-endian xtensa FLAT images which after this change fail to start with the following message:

  binfmt_flat: reloc outside program 0x24c80100 (0 - 0x6e430/0x56a20)

Fix it by preserving 'update_text' when building for xtensa.

This fix is a modified version of an original fix by Max Filippov <jcmvbkbc@gmail.com>. This commit message was his, though his Signed-off-by has been dropped due to it being a different fix.

The relocation code is used "as-is" but a different entry path into it ensures that "update_text" is not cleared for Xtensa.

Fixes: 5e08f1968316 ("Don't always update text in !pic_with_got case")
Reported-by: Niklas Cassel <niklas.cassel@wdc.com>