### PR TITLE
Re-add compatibility with RV32 NOMMU

### DIFF
--- a/elf2flt.c
+++ b/elf2flt.c
@@ -81,7 +81,7 @@ const char *elf2flt_progname;
 #include <elf/v850.h>
 #elif defined(TARGET_xtensa)
 #include <elf/xtensa.h>
-#elif defined(TARGET_riscv64)
+#elif defined(TARGET_riscv64) || defined(TARGET_riscv32)
 #include <elf/riscv.h>
 #endif
 
@@ -127,6 +127,8 @@ const char *elf2flt_progname;
 #define ARCH	"xtensa"
 #elif defined(TARGET_riscv64)
 #define ARCH	"riscv64"
+#elif defined(TARGET_riscv32)
+#define ARCH	"riscv32"
 #else
 #error "Don't know how to support your CPU architecture??"
 #endif
@@ -822,7 +824,7 @@ output_relocs (
 					goto good_32bit_resolved_reloc_update_text;
 				default:
 					goto bad_resolved_reloc;
-#elif defined(TARGET_riscv64)
+#elif defined(TARGET_riscv64) || defined(TARGET_riscv32)
 				case R_RISCV_NONE:
 				case R_RISCV_32_PCREL:
 				case R_RISCV_ADD8:

--- a/ld-elf2flt.c
+++ b/ld-elf2flt.c
@@ -327,7 +327,7 @@ static int do_final_link(void)
 	/* riscv adds a global pointer symbol to the linker file with the
 	   "RISCV_GP:" prefix. Remove the prefix for riscv64 architecture and
 	   the entire line for other architectures. */
-	if (streq(TARGET_CPU, "riscv64"))
+	if (streq(TARGET_CPU, "riscv64") || streq(TARGET_CPU, "riscv32"))
 		append_sed(&sed, "^RISCV_GP:", "");
 	else
 		append_sed(&sed, "^RISCV_GP:", NULL);


### PR DESCRIPTION
Apply Yimin Gu's fixes to elf2flt to allow riscv 32 to use the same relocation mechansims as riscv 64.

Original copy was passed around the buildroot list, but, it would be helpful for this to be upstream.

You can see the original patch here:

https://github.com/uclinux-dev/elf2flt/commit/533050320b13d7f026088c0963eb860beb4c014d

It looks like the change was stomped in a merge.